### PR TITLE
Bump httpclient from 4.3.4 to 4.5.13

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -19,7 +19,7 @@
         <dependency>
     		<groupId>org.apache.httpcomponents</groupId>
     		<artifactId>httpclient</artifactId>
-    		<version>4.3.4</version>
+    		<version>4.5.13</version>
 		</dependency>
 		<dependency>
     		<groupId>org.zeroturnaround</groupId>


### PR DESCRIPTION
Bumps httpclient from 4.3.4 to 4.5.13.

---
updated-dependencies:
- dependency-name: org.apache.httpcomponents:httpclient dependency-type: direct:production ...